### PR TITLE
Refactor for Scheduler and SMTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # aurora-forecast
-A simple python app that sends you emails when the Kp index is above a certain value. The script visits the NOAA website, and if the Kp index (a measure of solar activity) is equal to or above 5, I use the SendGrid API to send myself an email. This way, I can go see the northern lights when the solar activity is unusually high. You can find NOAA's 3-day aurora forecast here: https://services.swpc.noaa.gov/text/3-day-forecast.txt
+A simple python app that sends you emails when the Kp index is above a certain value. The script visits the NOAA website, and if the Kp index (a measure of solar activity) is equal to or above 5, I use the SendGrid API to send myself an email (alternatively, SMTP can be used). This way, I can go see the northern lights when the solar activity is unusually high. You can find NOAA's 3-day aurora forecast here: https://services.swpc.noaa.gov/text/3-day-forecast.txt.
 
 - To host this on PythonAnywhere as a scheduled task that runs once a morning, the file get_forecast.py can be run by itself
 - To run continuously, with scheduled time(s) to send the email, the file run_daily.py can be run.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # aurora-forecast
-A simple python app that sends you emails when the Kp index is above a certain value. I host this on PythonAnywhere as a scheduled task that runs once a morning. The script visits the NOAA website, and if the Kp index (a measure of solar activity) is equal to or above 5, I use the SendGrid API to send myself an email. This way, I can go see the northern lights when the solar activity is unusually high. You can find NOAA's 3-day aurora forecast here: https://services.swpc.noaa.gov/text/3-day-forecast.txt
+A simple python app that sends you emails when the Kp index is above a certain value. The script visits the NOAA website, and if the Kp index (a measure of solar activity) is equal to or above 5, I use the SendGrid API to send myself an email. This way, I can go see the northern lights when the solar activity is unusually high. You can find NOAA's 3-day aurora forecast here: https://services.swpc.noaa.gov/text/3-day-forecast.txt
+
+- To host this on PythonAnywhere as a scheduled task that runs once a morning, the file get_forecast.py can be run by itself
+- To run continuously, with scheduled time(s) to send the email, the file run_daily.py can be run.
 
 Some of this solar activity stuff moves in decade-long-ish cycles. In 2023, we're approaching a peak in solar activity. Here's a little chart showing some historical Kp index readings:
 

--- a/get_forecast.py
+++ b/get_forecast.py
@@ -1,6 +1,9 @@
 from sendgrid_mail import sendgrid_send
 from noaa_parser import get_data
 
+# Kp value threshold from when to send an email
+KP_THRESHOLD = 5
+
 # specify email here
 recipient_emails = [
     'THE EMAIL OF THE PERSON WHO WILL GET THE EMAIL GOES HERE',
@@ -19,10 +22,9 @@ email_endpoints = [
 df = get_data()
 # find the max Kp value over the next 3 days:
 max_value = df['value'].max()
-print(f"max_value={max_value}")
 
 # If the forecast Kp index will be equal to or above 5 at any point in the next 3 days, send an email alert using the "SendGrid" service:
-if max_value >= 5:
+if max_value >= KP_THRESHOLD:
     email_content = ("\nAt " + str(df.iloc[0]['time']) + ' on ' + str(df.iloc[0]['variable']) +
                      ' the Kp index is forecast to be ' + str(df.iloc[0]['value']) + '!' +
                      '\n\n\nFor more details, visit:\n\n' + 'https://services.swpc.noaa.gov/text/3-day-forecast.txt')

--- a/get_forecast.py
+++ b/get_forecast.py
@@ -2,36 +2,42 @@ from smtp_mail import SmtpMail
 from sendgrid_mail import SendgridMail
 from noaa_parser import get_data
 
-# Kp value threshold from when to send an email
-KP_THRESHOLD = 5
 
-# specify email here
-recipient_emails = [
-    'THE EMAIL OF THE PERSON WHO WILL GET THE EMAIL GOES HERE',
-    # 'IF NEEDED, ADD MORE RECIPIENT ADDRESSES IN THIS LIST'
-]
-sender_email = 'YOUR SENDER EMAIL GOES HERE'
-sender_name = 'YOUR NAME'
-email_topic = "Aurora forecast"
+def get_forecast():
+    # Kp value threshold from when to send an email
+    KP_THRESHOLD = 1  # noqa
 
-# add the email send functions (sendgrid and/or SMTP)
-email_endpoints = [
-    SmtpMail("SMTP HOST GOES HERE (ip/url)", "SMTP PORT GOES HERE", "SMTP PASSWORD GOES HERE", sender_email, sender_name),
-    SendgridMail('INPUT YOUR SENDGRID API KEY HERE', sender_email)
-]
+    # specify email here
+    recipient_emails = [
+        'THE EMAIL OF THE PERSON WHO WILL GET THE EMAIL GOES HERE',
+        # 'IF NEEDED, ADD MORE RECIPIENT ADDRESSES IN THIS LIST'
+    ]
+    sender_email = 'YOUR SENDER EMAIL GOES HERE'
+    sender_name = 'YOUR NAME'
+    email_topic = "Aurora forecast"
 
-# get the data from NOAA website
-df = get_data()
-# find the max Kp value over the next 3 days:
-max_value = df['value'].max()
+    # add the email send functions (sendgrid and/or SMTP)
+    email_endpoints = [
+        SmtpMail("SMTP HOST GOES HERE (ip/url)", "SMTP PORT GOES HERE", "SMTP PASSWORD GOES HERE", sender_email, sender_name),
+        SendgridMail('INPUT YOUR SENDGRID API KEY HERE', sender_email)
+    ]
 
-# If the forecast Kp index will be equal to or above threshold at any point in the next 3 days,
-# send an email alert using the service(s) specified above:
-if max_value >= KP_THRESHOLD:
-    email_content = ("\nAt " + str(df.iloc[0]['time']) + ' on ' + str(df.iloc[0]['variable']) +
-                     ' the Kp index is forecast to be ' + str(df.iloc[0]['value']) + '!' +
-                     '\n\n\nFor more details, visit:\n\n' + 'https://services.swpc.noaa.gov/text/3-day-forecast.txt')
-    for endpoint in email_endpoints:
-        for address in recipient_emails:
-            endpoint.send_msg(address, email_topic, email_content)
+    # get the data from NOAA website
+    df = get_data()
+    # find the max Kp value over the next 3 days:
+    max_value = df['value'].max()
 
+    # If the forecast Kp index will be equal to or above threshold at any point in the next 3 days,
+    # send an email alert using the service(s) specified above:
+    if max_value >= KP_THRESHOLD:
+        email_content = ("\nAt " + str(df.iloc[0]['time']) + ' on ' + str(df.iloc[0]['variable']) +
+                         ' the Kp index is forecast to be ' + str(df.iloc[0]['value']) + '!' +
+                         '\n\n\nFor more details, visit:\n\n' + 'https://services.swpc.noaa.gov/text/3-day-forecast.txt')
+        for endpoint in email_endpoints:
+            if endpoint is not None:
+                for address in recipient_emails:
+                    endpoint.send_msg(address, email_topic, email_content)
+
+
+if __name__ == "__main__":
+    get_forecast()

--- a/get_forecast.py
+++ b/get_forecast.py
@@ -1,10 +1,11 @@
 from datetime import datetime
-from smtp_mail import SmtpMail
-from sendgrid_mail import SendgridMail
+
 from noaa_parser import get_data
+from sendgrid_mail import SendgridMail
+from smtp_mail import SmtpMail
 
 # Kp value threshold from when to send an email
-KP_THRESHOLD = 5  # noqa
+KP_THRESHOLD = 5
 
 # specify email here
 recipient_emails = [
@@ -26,7 +27,7 @@ def get_forecast(add_timestamp=False):
     # find the max Kp value over the next 3 days:
     max_value = df['value'].max()
     # If the forecast Kp index will be equal to or above threshold at any point in the next 3 days,
-    # send an email alert using the service(s) specified above:
+    # send an email alert using the service specified above:
     if max_value >= KP_THRESHOLD:
         email_content = ("\nAt " + str(df.iloc[0]['time']) + ' on ' + str(df.iloc[0]['variable']) +
                          ' the Kp index is forecast to be ' + str(df.iloc[0]['value']) + '!' +
@@ -39,5 +40,6 @@ def get_forecast(add_timestamp=False):
     return max_value
 
 
+# if this script is run, run the forecast function
 if __name__ == "__main__":
     get_forecast()

--- a/get_forecast.py
+++ b/get_forecast.py
@@ -1,74 +1,32 @@
-import pandas as pd
-import re
-from io import StringIO
-import datetime
-from urllib.request import urlopen
-import sendgrid
-from sendgrid.helpers.mail import Mail, Email, To, Content
+from sendgrid_mail import sendgrid_send
+from noaa_parser import get_data
 
-# the NOAA website we'll get the aurora forecast from:
-link = "https://services.swpc.noaa.gov/text/3-day-forecast.txt"
-# Open the webpage and grab the text on the page (the forecast)
-f = urlopen(link)
-myfile = f.read()
-text = myfile.decode('utf-8')
+# specify email here
+recipient_emails = [
+    'THE EMAIL OF THE PERSON WHO WILL GET THE EMAIL GOES HERE',
+    # 'IF NEEDED, ADD MORE RECIPIENT ADDRESSES IN THIS LIST'
+]
+sender_email = 'YOUR SENDER EMAIL GOES HERE'
+email_topic = "Aurora forecast"
 
-# Grab the subset of the text on the page that's the table with the forecast over the next 3 days:
-current_year = datetime.date.today().year
-first_string_subset = text.split("NOAA Kp index breakdown", 1)[1]
-second_string_subset = first_string_subset.split(str(current_year), 1)[1]
-third_string_subset = second_string_subset.split("Rationale", 1)[0]
+# assign the email send function (sendgrid or SMTP)
+email_endpoints = [
+    # smtp_send,
+    sendgrid_send
+]
 
-# remove parentheses & brackets and the text between those parentheses & brackets:
-clean_table = re.sub("[\(\[].*?[\)\]]", "", third_string_subset)
-
-# turn that text table into a pandas dataframe:
-STRINGDATA = StringIO(clean_table)
-raw_data = pd.read_csv(STRINGDATA, sep="\n|\s+", header=None)
-
-# drop the first row:
-df = raw_data.iloc[1:]
-# drop some columns that are all "NA"
-df = df.dropna(axis=1, how='all')
-
-# the next few lines deal with the data table headers, which are the dates of the next 3 days, in the format like this:
-# Aug 9      Aug 10      Aug 11
-# Replace all the instances of a string of spaces witha single space; remove leading and trailing space
-headers = re.sub("\s+", " ", raw_data.iloc[0].to_string(index=False)).strip()
-# create a list that has each date. This is done using a regex phrase that looks for 3 letters followed by a space, then 1 or 2 digits:
-col_names = re.findall("[A-Za-z][A-Za-z][A-Za-z]\s\d{1,2}", headers)
-# add "time" to the front of the list. The first variable/column in the table is the time of the day/night
-col_names.insert(0, 'time')
-# add our cleaned up column names to the dataframe with the Kp values
-df.columns = col_names
-
-# convert the data table from wide to long format
-df = pd.melt(df, id_vars='time', value_vars=col_names[1:])
-df['value'] = pd.to_numeric(df['value'])
-# rank the Kp values, then order the data table so the biggest values are at the top of the table:
-df['rank'] = df['value'].rank(method='first', ascending=False)
-df = df.sort_values(by=['rank'])
-df = df[0:5]
-
+# get the data from NOAA website
+df = get_data()
 # find the max Kp value over the next 3 days:
 max_value = df['value'].max()
-
+print(f"max_value={max_value}")
 
 # If the forecast Kp index will be equal to or above 5 at any point in the next 3 days, send an email alert using the "SendGrid" service:
-if (max_value >= 5):
-    sg = sendgrid.SendGridAPIClient(api_key='INPUT YOUR SENDGRID API KEY HERE')
-    from_email = Email('YOUR SENDER EMAIL GOES HERE')  # Change to your verified sender
-    to_email = To('THE EMAIL OF THE PERSON WHO WILL GET THE EMAIL GOES HERE')  # Change to your recipient
-    subject = "Aurora forecast"
-    content = Content("text/plain", "\nAt " +
-                    str(df.iloc[0]['time']) + ' on ' + str(df.iloc[0]['variable']) +
-                    ' the Kp index is forecast to be ' + str(df.iloc[0]['value']) + '!' +
-                    '\n\n\nFor more details, visit:\n\n' + 'https://services.swpc.noaa.gov/text/3-day-forecast.txt')
-    mail = Mail(from_email, to_email, subject, content)
-    # Get a JSON-ready representation of the Mail object
-    mail_json = mail.get()
-    # Send an HTTP POST request to /mail/send
-    response = sg.client.mail.send.post(request_body=mail_json)
-    #print(response.status_code)
-    #print(response.headers)
+if max_value >= 5:
+    email_content = ("\nAt " + str(df.iloc[0]['time']) + ' on ' + str(df.iloc[0]['variable']) +
+                     ' the Kp index is forecast to be ' + str(df.iloc[0]['value']) + '!' +
+                     '\n\n\nFor more details, visit:\n\n' + 'https://services.swpc.noaa.gov/text/3-day-forecast.txt')
+    for endpoint in email_endpoints:
+        for address in recipient_emails:
+            endpoint(sender_email, address, email_topic, email_content)
 

--- a/get_forecast.py
+++ b/get_forecast.py
@@ -1,7 +1,7 @@
+from datetime import datetime
 from smtp_mail import SmtpMail
 from sendgrid_mail import SendgridMail
 from noaa_parser import get_data
-
 
 # Kp value threshold from when to send an email
 KP_THRESHOLD = 5  # noqa
@@ -15,11 +15,9 @@ sender_email = 'YOUR SENDER EMAIL GOES HERE'
 sender_name = 'YOUR NAME'
 email_topic = "Aurora forecast"
 
-# add the email send functions (sendgrid and/or SMTP)
-email_services = [
-    SmtpMail("SMTP HOST GOES HERE (ip/url)", "SMTP PORT GOES HERE", "SMTP PASSWORD GOES HERE", sender_email, sender_name),
-    SendgridMail('INPUT YOUR SENDGRID API KEY HERE', sender_email)
-]
+# add the email send function (sendgrid or SMTP)
+email_service = SendgridMail('INPUT YOUR SENDGRID API KEY HERE', sender_email)
+# email_service = SmtpMail("SMTP HOST (ip/url)", "SMTP PORT", "SMTP PASSWORD", sender_email, sender_name)
 
 
 def get_forecast(add_timestamp=False):
@@ -35,10 +33,9 @@ def get_forecast(add_timestamp=False):
                          '\n\n\nFor more details, visit:\n\n' +
                          'https://services.swpc.noaa.gov/text/3-day-forecast.txt')
         if add_timestamp:
-            email_content = email_content + f'\n\nReport created on {str(datetime.now()).split('.')[0]}UT'
-        for endpoint in email_services:
-            for address in recipient_emails:
-                endpoint.send_msg(address, email_topic, email_content)
+            email_content = email_content + f'\n\nReport created on {str(datetime.now()).split(".")[0]}UT'
+        for address in recipient_emails:
+            email_service.send_msg(address, email_topic, email_content)
     return max_value
 
 

--- a/get_forecast.py
+++ b/get_forecast.py
@@ -22,22 +22,25 @@ email_services = [
 ]
 
 
-def get_forecast():
+def get_forecast(add_timestamp=False):
     # get the data from NOAA website
     df = get_data()
     # find the max Kp value over the next 3 days:
     max_value = df['value'].max()
-    print(f"max={max_value}")
     # If the forecast Kp index will be equal to or above threshold at any point in the next 3 days,
     # send an email alert using the service(s) specified above:
     if max_value >= KP_THRESHOLD:
         email_content = ("\nAt " + str(df.iloc[0]['time']) + ' on ' + str(df.iloc[0]['variable']) +
                          ' the Kp index is forecast to be ' + str(df.iloc[0]['value']) + '!' +
-                         '\n\n\nFor more details, visit:\n\n' + 'https://services.swpc.noaa.gov/text/3-day-forecast.txt')
+                         '\n\n\nFor more details, visit:\n\n' +
+                         'https://services.swpc.noaa.gov/text/3-day-forecast.txt')
+        if add_timestamp:
+            email_content = email_content + f'\n\nReport created on {str(datetime.now()).split('.')[0]}UT'
         for endpoint in email_services:
             for address in recipient_emails:
                 endpoint.send_msg(address, email_topic, email_content)
     return max_value
+
 
 if __name__ == "__main__":
     get_forecast()

--- a/get_forecast.py
+++ b/get_forecast.py
@@ -3,41 +3,41 @@ from sendgrid_mail import SendgridMail
 from noaa_parser import get_data
 
 
+# Kp value threshold from when to send an email
+KP_THRESHOLD = 5  # noqa
+
+# specify email here
+recipient_emails = [
+    'THE EMAIL OF THE PERSON WHO WILL GET THE EMAIL GOES HERE',
+    # 'IF NEEDED, ADD MORE RECIPIENT ADDRESSES IN THIS LIST'
+]
+sender_email = 'YOUR SENDER EMAIL GOES HERE'
+sender_name = 'YOUR NAME'
+email_topic = "Aurora forecast"
+
+# add the email send functions (sendgrid and/or SMTP)
+email_services = [
+    SmtpMail("SMTP HOST GOES HERE (ip/url)", "SMTP PORT GOES HERE", "SMTP PASSWORD GOES HERE", sender_email, sender_name),
+    SendgridMail('INPUT YOUR SENDGRID API KEY HERE', sender_email)
+]
+
+
 def get_forecast():
-    # Kp value threshold from when to send an email
-    KP_THRESHOLD = 1  # noqa
-
-    # specify email here
-    recipient_emails = [
-        'THE EMAIL OF THE PERSON WHO WILL GET THE EMAIL GOES HERE',
-        # 'IF NEEDED, ADD MORE RECIPIENT ADDRESSES IN THIS LIST'
-    ]
-    sender_email = 'YOUR SENDER EMAIL GOES HERE'
-    sender_name = 'YOUR NAME'
-    email_topic = "Aurora forecast"
-
-    # add the email send functions (sendgrid and/or SMTP)
-    email_endpoints = [
-        SmtpMail("SMTP HOST GOES HERE (ip/url)", "SMTP PORT GOES HERE", "SMTP PASSWORD GOES HERE", sender_email, sender_name),
-        SendgridMail('INPUT YOUR SENDGRID API KEY HERE', sender_email)
-    ]
-
     # get the data from NOAA website
     df = get_data()
     # find the max Kp value over the next 3 days:
     max_value = df['value'].max()
-
+    print(f"max={max_value}")
     # If the forecast Kp index will be equal to or above threshold at any point in the next 3 days,
     # send an email alert using the service(s) specified above:
     if max_value >= KP_THRESHOLD:
         email_content = ("\nAt " + str(df.iloc[0]['time']) + ' on ' + str(df.iloc[0]['variable']) +
                          ' the Kp index is forecast to be ' + str(df.iloc[0]['value']) + '!' +
                          '\n\n\nFor more details, visit:\n\n' + 'https://services.swpc.noaa.gov/text/3-day-forecast.txt')
-        for endpoint in email_endpoints:
-            if endpoint is not None:
-                for address in recipient_emails:
-                    endpoint.send_msg(address, email_topic, email_content)
-
+        for endpoint in email_services:
+            for address in recipient_emails:
+                endpoint.send_msg(address, email_topic, email_content)
+    return max_value
 
 if __name__ == "__main__":
     get_forecast()

--- a/get_forecast.py
+++ b/get_forecast.py
@@ -1,4 +1,5 @@
-from sendgrid_mail import sendgrid_send
+from smtp_mail import SmtpMail
+from sendgrid_mail import SendgridMail
 from noaa_parser import get_data
 
 # Kp value threshold from when to send an email
@@ -10,12 +11,13 @@ recipient_emails = [
     # 'IF NEEDED, ADD MORE RECIPIENT ADDRESSES IN THIS LIST'
 ]
 sender_email = 'YOUR SENDER EMAIL GOES HERE'
+sender_name = 'YOUR NAME'
 email_topic = "Aurora forecast"
 
-# assign the email send function (sendgrid or SMTP)
+# add the email send functions (sendgrid and/or SMTP)
 email_endpoints = [
-    # smtp_send,
-    sendgrid_send
+    SmtpMail("SMTP HOST GOES HERE (ip/url)", "SMTP PORT GOES HERE", "SMTP PASSWORD GOES HERE", sender_email, sender_name),
+    SendgridMail('INPUT YOUR SENDGRID API KEY HERE', sender_email)
 ]
 
 # get the data from NOAA website
@@ -23,12 +25,13 @@ df = get_data()
 # find the max Kp value over the next 3 days:
 max_value = df['value'].max()
 
-# If the forecast Kp index will be equal to or above 5 at any point in the next 3 days, send an email alert using the "SendGrid" service:
+# If the forecast Kp index will be equal to or above threshold at any point in the next 3 days,
+# send an email alert using the service(s) specified above:
 if max_value >= KP_THRESHOLD:
     email_content = ("\nAt " + str(df.iloc[0]['time']) + ' on ' + str(df.iloc[0]['variable']) +
                      ' the Kp index is forecast to be ' + str(df.iloc[0]['value']) + '!' +
                      '\n\n\nFor more details, visit:\n\n' + 'https://services.swpc.noaa.gov/text/3-day-forecast.txt')
     for endpoint in email_endpoints:
         for address in recipient_emails:
-            endpoint(sender_email, address, email_topic, email_content)
+            endpoint.send_msg(address, email_topic, email_content)
 

--- a/noaa_parser.py
+++ b/noaa_parser.py
@@ -4,6 +4,7 @@ import re
 from io import StringIO
 import pandas as pd
 
+
 def get_data():
     # the NOAA website we'll get the aurora forecast from:
     link = "https://services.swpc.noaa.gov/text/3-day-forecast.txt"

--- a/noaa_parser.py
+++ b/noaa_parser.py
@@ -1,7 +1,8 @@
 import datetime
-from urllib.request import urlopen
 import re
 from io import StringIO
+from urllib.request import urlopen
+
 import pandas as pd
 
 

--- a/noaa_parser.py
+++ b/noaa_parser.py
@@ -1,0 +1,51 @@
+import datetime
+from urllib.request import urlopen
+import re
+from io import StringIO
+import pandas as pd
+
+def get_data():
+    # the NOAA website we'll get the aurora forecast from:
+    link = "https://services.swpc.noaa.gov/text/3-day-forecast.txt"
+    # Open the webpage and grab the text on the page (the forecast)
+    f = urlopen(link)
+    myfile = f.read()
+    text = myfile.decode('utf-8')
+
+    # Grab the subset of the text on the page that's the table with the forecast over the next 3 days:
+    current_year = datetime.date.today().year
+    first_string_subset = text.split("NOAA Kp index breakdown", 1)[1]
+    second_string_subset = first_string_subset.split(str(current_year), 1)[1]
+    third_string_subset = second_string_subset.split("Rationale", 1)[0]
+
+    # remove parentheses & brackets and the text between those parentheses & brackets:
+    clean_table = re.sub("[\(\[].*?[\)\]]", "", third_string_subset)
+
+    # turn that text table into a pandas dataframe:
+    STRINGDATA = StringIO(clean_table)
+    raw_data = pd.read_csv(STRINGDATA, sep="\n|\s+", header=None, engine='python')
+
+    # drop the first row:
+    df = raw_data.iloc[1:]
+    # drop some columns that are all "NA"
+    df = df.dropna(axis=1, how='all')
+
+    # the next few lines deal with the data table headers, which are the dates of the next 3 days, in the format like this:
+    # Aug 9      Aug 10      Aug 11
+    # Replace all the instances of a string of spaces witha single space; remove leading and trailing space
+    headers = re.sub("\s+", " ", raw_data.iloc[0].to_string(index=False)).strip()
+    # create a list that has each date. This is done using a regex phrase that looks for 3 letters followed by a space, then 1 or 2 digits:
+    col_names = re.findall("[A-Za-z][A-Za-z][A-Za-z]\s\d{1,2}", headers)
+    # add "time" to the front of the list. The first variable/column in the table is the time of the day/night
+    col_names.insert(0, 'time')
+    # add our cleaned up column names to the dataframe with the Kp values
+    df.columns = col_names
+
+    # convert the data table from wide to long format
+    df = pd.melt(df, id_vars='time', value_vars=col_names[1:])
+    df['value'] = pd.to_numeric(df['value'])
+    # rank the Kp values, then order the data table so the biggest values are at the top of the table:
+    df['rank'] = df['value'].rank(method='first', ascending=False)
+    df = df.sort_values(by=['rank'])
+    df = df[0:5]
+    return df

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+sendgrid

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-pandas
+schedule
 sendgrid
+pandas

--- a/run_daily.py
+++ b/run_daily.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from time import sleep
+import schedule
+from get_forecast import get_forecast
+from urllib.error import URLError
+
+
+def run_get_forecast():
+    max_value = get_forecast()
+    print(f"ran script at {datetime.now()}, max value was {max_value}")
+
+
+# set at which time(s) the get_forecast script shall run
+schedule.every().day.at("06:00:00").do(run_get_forecast)
+# schedule.every().day.at("18:00:00").do(run_get_forecast)
+
+while True:
+    try:
+        schedule.run_pending()
+    except URLError as e:
+        print(f"WARNING: catched URL error at {datetime.now()}. Exception: {e}")
+    sleep(1)

--- a/run_daily.py
+++ b/run_daily.py
@@ -1,8 +1,10 @@
 from datetime import datetime
 from time import sleep
-import schedule
-from get_forecast import get_forecast
 from urllib.error import URLError
+
+import schedule
+
+from get_forecast import get_forecast
 
 
 def run_get_forecast():
@@ -10,7 +12,9 @@ def run_get_forecast():
     print(f"ran script at {datetime.now()}, max value was {max_value}")
 
 
+# run once after start, to check if it works
 run_get_forecast()
+
 # set at which time(s) the get_forecast script shall run (UTC)
 schedule.every().day.at("04:00:00").do(run_get_forecast)
 schedule.every().day.at("16:00:00").do(run_get_forecast)

--- a/run_daily.py
+++ b/run_daily.py
@@ -6,13 +6,14 @@ from urllib.error import URLError
 
 
 def run_get_forecast():
-    max_value = get_forecast()
+    max_value = get_forecast(add_timestamp=True)
     print(f"ran script at {datetime.now()}, max value was {max_value}")
 
 
-# set at which time(s) the get_forecast script shall run
-schedule.every().day.at("06:00:00").do(run_get_forecast)
-# schedule.every().day.at("18:00:00").do(run_get_forecast)
+run_get_forecast()
+# set at which time(s) the get_forecast script shall run (UTC)
+schedule.every().day.at("04:00:00").do(run_get_forecast)
+schedule.every().day.at("16:00:00").do(run_get_forecast)
 
 while True:
     try:

--- a/sendgrid_mail.py
+++ b/sendgrid_mail.py
@@ -1,5 +1,5 @@
 from sendgrid import SendGridAPIClient
-from sendgrid.helpers.mail import Mail, Email, To, Content
+from sendgrid.helpers.mail import Content, Email, Mail, To
 
 
 class SendgridMail:

--- a/sendgrid_mail.py
+++ b/sendgrid_mail.py
@@ -2,16 +2,20 @@ from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail, Email, To, Content
 
 
-def sendgrid_send(from_email_str, to_email_str, subject_str, content_str):
-    sg = SendGridAPIClient(api_key='INPUT YOUR SENDGRID API KEY HERE')
-    from_email = Email(from_email_str)  # Change to your verified sender
-    to_email = To(to_email_str)  # Change to your recipient
-    subject = subject_str
-    content = Content("text/plain", content_str)
-    mail = Mail(from_email, to_email, subject, content)
-    # Get a JSON-ready representation of the Mail object
-    mail_json = mail.get()
-    # Send an HTTP POST request to /mail/send
-    response = sg.client.mail.send.post(request_body=mail_json)
-    #print(response.status_code)
-    #print(response.headers)
+class SendgridMail:
+    def __init__(self, sendgrid_api_key, sendgrid_sender):
+        self.sender = sendgrid_sender
+        self.sendgrid_api_k = sendgrid_api_key
+
+    def send_msg(self, recipient, subject, body):
+        sg = SendGridAPIClient(api_key=self.sendgrid_api_k)
+        from_email = Email(self.sender)  # Change to your verified sender
+        to_email = To(recipient)  # Change to your recipient
+        content = Content("text/plain", body)
+        mail = Mail(from_email, to_email, subject, content)
+        # Get a JSON-ready representation of the Mail object
+        mail_json = mail.get()
+        # Send an HTTP POST request to /mail/send
+        response = sg.client.mail.send.post(request_body=mail_json)
+        #print(response.status_code)
+        #print(response.headers)

--- a/sendgrid_mail.py
+++ b/sendgrid_mail.py
@@ -1,0 +1,17 @@
+from sendgrid import SendGridAPIClient
+from sendgrid.helpers.mail import Mail, Email, To, Content
+
+
+def sendgrid_send(from_email_str, to_email_str, subject_str, content_str):
+    sg = SendGridAPIClient(api_key='INPUT YOUR SENDGRID API KEY HERE')
+    from_email = Email(from_email_str)  # Change to your verified sender
+    to_email = To(to_email_str)  # Change to your recipient
+    subject = subject_str
+    content = Content("text/plain", content_str)
+    mail = Mail(from_email, to_email, subject, content)
+    # Get a JSON-ready representation of the Mail object
+    mail_json = mail.get()
+    # Send an HTTP POST request to /mail/send
+    response = sg.client.mail.send.post(request_body=mail_json)
+    #print(response.status_code)
+    #print(response.headers)

--- a/smtp_mail.py
+++ b/smtp_mail.py
@@ -1,0 +1,28 @@
+from smtplib import SMTP, SMTPException
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+
+class SmtpMail:
+    def __init__(self, host, port, password, sender, sender_name):
+        self.smtp_ip = host
+        self.smtp_port = port
+        self.smtp_email = sender
+        self.smtp_pw = password
+        self.smtp_name = sender_name
+
+    def send_msg(self, recipient, subject, body):
+        try:
+            mail_server = SMTP(self.smtp_ip, self.smtp_port)
+            mail_server.login(self.smtp_email, self.smtp_pw)
+            message_from = u"{} <{}>".format(self.smtp_name, self.smtp_email)
+            msg = MIMEMultipart("alternative")
+            msg['From'] = message_from
+            msg['To'] = recipient
+            msg['Subject'] = subject
+            message_text = body
+            msg.attach(MIMEText(message_text))
+            mail_server.sendmail(msg['From'], msg['To'], msg.as_string())
+            mail_server.quit()
+        except SMTPException:
+            print("failed to send mail!!!")

--- a/smtp_mail.py
+++ b/smtp_mail.py
@@ -1,6 +1,6 @@
-from smtplib import SMTP, SMTPException
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from smtplib import SMTP, SMTPException
 
 
 class SmtpMail:


### PR DESCRIPTION
Hello

I found your aurora forecast script when I wanted to create something very similar. So first of all, thanks for creating this noaa txt parser with email functionality. It is very helpful and I was very happy not having to figure out the parsing of the data myself.

My use case is slightly different from yours in a way that I want to run a script continuously and use SMTP to send the email, instead of using sendgrid.

in the state checked into the repo, the get_forecast.py script retains the same functionality as it had before (maybe test with sendgrid before merging)

My changes are as follows:

- moved parsing into file noaa_parser.py. It retains your original functionality through the function get_data
- moved the sendgrid part to its own file and class to be able to use it as an object, so that it can easily be replaced by SMTP if needed (implements send_msg function)
- added file smtp_mail.py containing a class which can be swapped in instead of sendgrid, to use SMTP instead (also implements send_msg function)
- added run_daily.py file which uses the scheduler module to schedule email dispatches when run continuously
- add requirements.txt to track python package requirements, for convenience
- sorted the imports using isort and some other cosmetics


the email dispatcher can be chosen by commenting/uncommenting one of the lines in the get_forecast.py script:
```

# add the email send function (sendgrid or SMTP)
email_service = SendgridMail('INPUT YOUR SENDGRID API KEY HERE', sender_email)
# email_service = SmtpMail("SMTP HOST (ip/url)", "SMTP PORT", "SMTP PASSWORD", sender_email, sender_name)

```
